### PR TITLE
102 handle null snp allele values in associations to prevent api errors

### DIFF
--- a/src/main/resources/templates/docs-template.html
+++ b/src/main/resources/templates/docs-template.html
@@ -182,7 +182,7 @@
         <section>
             <h2>🧑‍💻 Examples of a few key ways you can use the GWAS API</h2>
             <p>
-                For hands-on, executable examples, please explore our collection of <a href="https://github.com/EBISPOT/gwas-rest-api/blob/3c2cb9093873400e3ca2f90bf3f3e304ed3269f7/docs/jupyter-notebooks/sample.ipynb" target="_blank">Jupyter Notebooks</a>.
+                For hands-on, executable examples, please explore our collection of <a href="https://colab.research.google.com/drive/1PDFJAWHN7O6WkZ_HteOkOWeAGnsOMRXR?usp=sharing" target="_blank">Jupyter Notebooks</a>.
             </p>
             <p>
                 For example, answering scientific questions like "what variants are associated with a particular disease?",


### PR DESCRIPTION
# Fix API error while processing null SNP alleles in association responses (fixes #102)

## Description
Fixes API errors when associations have null `snp_effect_allele` or `snp_risk_allele` values. Safely returns associations with missing alleles and adds unit tests.

## Changes
- Safely handle null `snp_effect_allele` and `snp_risk_allele` in association responses.
- Prevent `NullPointerException` when retrieving affected associations.
- Added unit tests.

## Impact
Associations with missing allele values are now returned without causing errors, improving API stability.

## Closes
#102
